### PR TITLE
Allow for deterministic yaml-to-dhall parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This allows the user to more easily generate type-safe configuration, through th
 ## Install
 For stability, users are encouraged to import from a tagged release, not from the master branch, and to watch for new releases. This project does not yet have rigorous testing set up for it and new commits on the master branch are prone to break compatiblility and are almost sure to change the import hash for the expression, thus the releases are currently `v0.x`.
 ```
-https://raw.githubusercontent.com/coralogix/dhall-utility-library/v0.5.0/package.dhall sha256:4cd1d3b99bacce564563aeec827b9cb988496795d82431716a913ff31d049128
+https://raw.githubusercontent.com/coralogix/dhall-utility-library/v0.6.0/package.dhall sha256:66eac38d50e5c59df947ee682d9554454e2276aa06263a730c89d6297294f7bf
 ```
 ## Maintainers
 [Ari Becker](https://github.com/ari-becker)

--- a/golang/Duration.dhall
+++ b/golang/Duration.dhall
@@ -1,15 +1,25 @@
-let Duration = < Seconds : Natural | Minutes : Natural | Hours : Natural >
+let Duration =
+      let Unit = < Seconds | Minutes | Hours >
+
+      in  { Type = { unit : Unit, magnitude : Natural }
+          , Unit
+          , Seconds =
+              λ(magnitude : Natural) → { magnitude, unit = Unit.Seconds }
+          , Minutes =
+              λ(magnitude : Natural) → { magnitude, unit = Unit.Minutes }
+          , Hours = λ(magnitude : Natural) → { magnitude, unit = Unit.Hours }
+          }
 
 let render =
       let render
-          : ∀(value : Duration) → Text
-          =   λ(value : Duration)
-            → merge
-                { Seconds = λ(it : Natural) → "${Natural/show it}s"
-                , Minutes = λ(it : Natural) → "${Natural/show it}m"
-                , Hours = λ(it : Natural) → "${Natural/show it}h"
+          : ∀(value : Duration.Type) → Text
+          = λ(value : Duration.Type) →
+              merge
+                { Seconds = "${Natural/show value.magnitude}s"
+                , Minutes = "${Natural/show value.magnitude}m"
+                , Hours = "${Natural/show value.magnitude}h"
                 }
-                value
+                value.unit
 
       let tests =
             { seconds = assert : render (Duration.Seconds 30) ≡ "30s"
@@ -19,20 +29,6 @@ let render =
 
       in  render
 
-let exports =
-    {- the Seconds, Minutes, and Hours exports are provided as helpers.
-    -- instead of needing to write:
-     --     let Duration = ./Duration.dhall
-     --     in Duration.Type.Seconds 30
-     -- you can instead write:
-     --     let Duration = ./Duration.dhall
-     --     in Duration.Seconds 30
-    -}
-      { Type = Duration
-      , Seconds = λ(value : Natural) → Duration.Seconds value
-      , Minutes = λ(value : Natural) → Duration.Minutes value
-      , Hours = λ(value : Natural) → Duration.Hours value
-      , render = render
-      }
+let exports = Duration ∧ { render }
 
 in  exports

--- a/golang/package.dhall
+++ b/golang/package.dhall
@@ -1,1 +1,4 @@
-{ Duration = ./Duration.dhall }
+{ Duration =
+      ./Duration.dhall sha256:1396fea99606ea308ac050de3c2c071489f1eb4287aff271c28968b5e271fb1a
+    ? ./Duration.dhall
+}

--- a/hcl/package.dhall
+++ b/hcl/package.dhall
@@ -1,1 +1,4 @@
-{ render = ./render.dhall }
+{ render =
+      ./render.dhall sha256:90ecbe444050a4df096396f8a02aa1de60f0481894d5e880155cbc6bba6d9479
+    ? ./render.dhall
+}

--- a/jvm/Heap.dhall
+++ b/jvm/Heap.dhall
@@ -1,21 +1,30 @@
-let Heap = < TB : Natural | GB : Natural | MB : Natural | KB : Natural >
+let Heap =
+      let Unit = < TB | GB | MB | KB >
+
+      in  { Type = { magnitude : Natural, unit : Unit }
+          , Unit
+          , TB = λ(magnitude : Natural) → { magnitude, unit = Unit.TB }
+          , GB = λ(magnitude : Natural) → { magnitude, unit = Unit.GB }
+          , MB = λ(magnitude : Natural) → { magnitude, unit = Unit.MB }
+          , KB = λ(magnitude : Natural) → { magnitude, unit = Unit.KB }
+          }
 
 let render =
       let size =
-              λ(heap : Heap)
-            → merge
-                { TB = λ(size : Natural) → "${Natural/show size}t"
-                , GB = λ(size : Natural) → "${Natural/show size}g"
-                , MB = λ(size : Natural) → "${Natural/show size}m"
-                , KB = λ(size : Natural) → "${Natural/show size}k"
+            λ(heap : Heap.Type) →
+              merge
+                { TB = "${Natural/show heap.magnitude}t"
+                , GB = "${Natural/show heap.magnitude}g"
+                , MB = "${Natural/show heap.magnitude}m"
+                , KB = "${Natural/show heap.magnitude}k"
                 }
-                heap
+                heap.unit
 
-      let xms = λ(value : Heap) → "-Xms${size value}"
+      let xms = λ(value : Heap.Type) → "-Xms${size value}"
 
-      let xmx = λ(value : Heap) → "-Xmx${size value}"
+      let xmx = λ(value : Heap.Type) → "-Xmx${size value}"
 
-      let fixed = λ(heap : Heap) → "${xms heap} ${xmx heap}"
+      let fixed = λ(heap : Heap.Type) → "${xms heap} ${xmx heap}"
 
       let tests =
             { size = assert : size (Heap.KB 512) ≡ "512k"
@@ -24,23 +33,8 @@ let render =
             , fixed = assert : fixed (Heap.MB 1024) ≡ "-Xms1024m -Xmx1024m"
             }
 
-      in  { text = size, xms = xms, xmx = xmx, fixed = fixed }
+      in  { text = size, xms, xmx, fixed }
 
-let exports =
-    {- the TB, GB, MB, KB exports are provided as helpers.
-    -- instead of needing to write :
-    --      let Heap = ./Heap.dhall
-    --      in Heap.Type.GB 2
-    -- you can instead write
-    --      let Heap = ./Heap.dhall
-    --      in Heap.GB 2
-    -}
-      { Types = Heap
-      , render = render
-      , TB = λ(value : Natural) → Heap.TB value
-      , GB = λ(value : Natural) → Heap.GB value
-      , MB = λ(value : Natural) → Heap.MB value
-      , KB = λ(value : Natural) → Heap.KB value
-      }
+let exports = Heap ∧ { render }
 
 in  exports

--- a/jvm/package.dhall
+++ b/jvm/package.dhall
@@ -1,1 +1,4 @@
-{ Heap = ./Heap.dhall }
+{ Heap =
+      ./Heap.dhall sha256:96f477d9a5435cdc7882dd0cd54e8a0652ffe983da4649ddbe599b49d9f4187b
+    ? ./Heap.dhall
+}

--- a/kubernetes/Compute.dhall
+++ b/kubernetes/Compute.dhall
@@ -1,14 +1,22 @@
-let Compute = < Millicpu : Natural | Cpu : Natural >
+let Compute =
+      let Unit = < Millicpu | Cpu >
+
+      in  { Type = { magnitude : Natural, unit : Unit }
+          , Unit
+          , Millicpu =
+              λ(magnitude : Natural) → { magnitude, unit = Unit.Millicpu }
+          , Cpu = λ(magnitude : Natural) → { magnitude, unit = Unit.Cpu }
+          }
 
 let render =
       let render
-          : ∀(value : Compute) → Text
-          =   λ(value : Compute)
-            → merge
-                { Millicpu = λ(it : Natural) → "${Natural/show it}m"
-                , Cpu = λ(it : Natural) → "${Natural/show it}"
+          : ∀(value : Compute.Type) → Text
+          = λ(value : Compute.Type) →
+              merge
+                { Millicpu = "${Natural/show value.magnitude}m"
+                , Cpu = "${Natural/show value.magnitude}"
                 }
-                value
+                value.unit
 
       let tests =
             { millicpu = assert : render (Compute.Millicpu 1000) ≡ "1000m"
@@ -17,19 +25,6 @@ let render =
 
       in  render
 
-let exports =
-    {- the Millicpu, Cpu exports are provided as helpers.
-    -- instead of needing to write:
-      --     let Compute = ./Compute.dhall
-      --     in Compute.Type.Millicpu 1000
-      -- you can instead write:
-      --     let Compute = ./Compute.dhall
-      --     in Compute.Millicpu 1000
-      -}
-      { Type = Compute
-      , Millicpu = λ(value : Natural) → Compute.Millicpu value
-      , Cpu = λ(value : Natural) → Compute.Cpu value
-      , render = render
-      }
+let exports = Compute ∧ { render }
 
 in  exports

--- a/kubernetes/Space.dhall
+++ b/kubernetes/Space.dhall
@@ -1,27 +1,31 @@
 let Space =
-      < EB : Natural
-      | PB : Natural
-      | TB : Natural
-      | GB : Natural
-      | MB : Natural
-      | KB : Natural
-      | Bytes : Natural
-      >
+      let Unit = < EB | PB | TB | GB | MB | KB | Bytes >
+
+      in  { Type = { magnitude : Natural, unit : Unit }
+          , Unit
+          , EB = λ(magnitude : Natural) → { magnitude, unit = Unit.EB }
+          , PB = λ(magnitude : Natural) → { magnitude, unit = Unit.PB }
+          , TB = λ(magnitude : Natural) → { magnitude, unit = Unit.TB }
+          , GB = λ(magnitude : Natural) → { magnitude, unit = Unit.GB }
+          , MB = λ(magnitude : Natural) → { magnitude, unit = Unit.MB }
+          , KB = λ(magnitude : Natural) → { magnitude, unit = Unit.KB }
+          , Bytes = λ(magnitude : Natural) → { magnitude, unit = Unit.Bytes }
+          }
 
 let render =
       let render
-          : ∀(value : Space) → Text
-          =   λ(value : Space)
-            → merge
-                { EB = λ(it : Natural) → "${Natural/show it}Ei"
-                , PB = λ(it : Natural) → "${Natural/show it}Pi"
-                , TB = λ(it : Natural) → "${Natural/show it}Ti"
-                , GB = λ(it : Natural) → "${Natural/show it}Gi"
-                , MB = λ(it : Natural) → "${Natural/show it}Mi"
-                , KB = λ(it : Natural) → "${Natural/show it}Ki"
-                , Bytes = λ(it : Natural) → Natural/show it
+          : ∀(value : Space.Type) → Text
+          = λ(value : Space.Type) →
+              merge
+                { EB = "${Natural/show value.magnitude}Ei"
+                , PB = "${Natural/show value.magnitude}Pi"
+                , TB = "${Natural/show value.magnitude}Ti"
+                , GB = "${Natural/show value.magnitude}Gi"
+                , MB = "${Natural/show value.magnitude}Mi"
+                , KB = "${Natural/show value.magnitude}Ki"
+                , Bytes = Natural/show value.magnitude
                 }
-                value
+                value.unit
 
       let tests =
             { eb = assert : render (Space.EB 1) ≡ "1Ei"
@@ -35,24 +39,6 @@ let render =
 
       in  render
 
-let exports =
-    {- the EB, PB, TB, GB, MB, KB and Bytes exports are provided as helpers.
-    -- instead of needing to write:
-      --     let Space = ./Space.dhall
-      --     in Space.Type.GB 100
-      -- you can instead write:
-      --     let Space = ./Space.dhall
-      --     in Space.GB 100
-      -}
-      { Type = Space
-      , EB = λ(value : Natural) → Space.EB value
-      , PB = λ(value : Natural) → Space.PB value
-      , TB = λ(value : Natural) → Space.TB value
-      , GB = λ(value : Natural) → Space.GB value
-      , MB = λ(value : Natural) → Space.MB value
-      , KB = λ(value : Natural) → Space.KB value
-      , Bytes = λ(value : Natural) → Space.Bytes value
-      , render = render
-      }
+let exports = Space ∧ { render }
 
 in  exports

--- a/kubernetes/package.dhall
+++ b/kubernetes/package.dhall
@@ -7,11 +7,20 @@
         -- This import is maintained here so that downstream doesn't need to
         -- update from `kubernetes.Duration` to `golang.Duration`.
         -}
-          ../golang/Duration.dhall
+            ../golang/Duration.dhall sha256:1396fea99606ea308ac050de3c2c071489f1eb4287aff271c28968b5e271fb1a
+          ? ../golang/Duration.dhall
 
     in  import
-, Image = ./Image.dhall
-, Compute = ./Compute.dhall
-, Space = ./Space.dhall
-, Memory = ./Memory.dhall
+, Image =
+      ./Image.dhall sha256:62d2eba8a654705779b2c947298698d8b93f5127b9c6f887ed9b526cae5cb757
+    ? ./Image.dhall
+, Compute =
+      ./Compute.dhall sha256:eae72b0977cc2348ea5f96010839bc4bdac95d56a6ba452678003836bf09fd0c
+    ? ./Compute.dhall
+, Space =
+      ./Space.dhall sha256:4bd705ca605d92dbde68cada44e0dbef5ea2a437adad0b2ac47f7af8b18578dc
+    ? ./Space.dhall
+, Memory =
+      ./Memory.dhall sha256:4bd705ca605d92dbde68cada44e0dbef5ea2a437adad0b2ac47f7af8b18578dc
+    ? ./Memory.dhall
 }

--- a/package.dhall
+++ b/package.dhall
@@ -1,7 +1,19 @@
-{ golang = ./golang/package.dhall
-, hcl = ./hcl/package.dhall
-, kubernetes = ./kubernetes/package.dhall
-, log = ./log/package.dhall
-, map = ./map/package.dhall
-, jvm = ./jvm/package.dhall
+{ golang =
+      ./golang/package.dhall sha256:d9502bfa7c143945ee41140fdafcbf1c21ac44d2388632571f70085ccf2414bf
+    ? ./golang/package.dhall
+, hcl =
+      ./hcl/package.dhall sha256:4fd384a427365c554a88cd58c02d4d03a772213b591664028797fdddb276681d
+    ? ./hcl/package.dhall
+, kubernetes =
+      ./kubernetes/package.dhall sha256:6f0b756217bc724e4fadedca2875cd7a469404c1c47a30e8716e59932dd37561
+    ? ./kubernetes/package.dhall
+, log =
+      ./log/package.dhall sha256:4602b9f70fdcd8de5169cffbe11870a851b69d56b1c4a4525b2c8df289ef8db5
+    ? ./log/package.dhall
+, map =
+      ./map/package.dhall sha256:e3dd5145bac09f9480664b35dcff007967e993ea5233ba7994404b7aaf62b92b
+    ? ./map/package.dhall
+, jvm =
+      ./jvm/package.dhall sha256:32a26cebf4ba9425fe1fd35e1079d52f01460209012cbfece97593bacff6db01
+    ? ./jvm/package.dhall
 }

--- a/shell.nix
+++ b/shell.nix
@@ -9,21 +9,19 @@ let
     }
   ) {};
 
-  dhall-haskell = import (
+  easy-dhall-nix = import (
     let
-      version = "1.31.0";
+      version = "1.33.1";
     in nixpkgs.fetchFromGitHub {
-      owner           = "dhall-lang";
-      repo            = "dhall-haskell";
-      rev             = version;
-      fetchSubmodules = true;
-      sha256          = "030kxbghm9k1r0amrfdlnz9kq2rqijr7pxhbv0bhcb5lrkzajjak";
-    }
-  );
+      owner  = "justinwoo";
+      repo   = "easy-dhall-nix";
+      rev    = "288ee825c326f352a5db194a024bd3e1f2f735b2";
+      sha256 = "12v4ql1nm1famz8r80k1xkkdgj7285vy2vn16iili0qwvz3i98ah";
+      }
+    ) {};
 
 in nixpkgs.mkShell {
   buildInputs = [
-    dhall-haskell.dhall
-    nixpkgs.git
+    easy-dhall-nix.dhall-simple
   ];
 }


### PR DESCRIPTION
The yaml-to-dhall tool does not permit for deterministic parsing into a
union where the alternatives have the same type. See:
https://github.com/dhall-lang/dhall-haskell/issues/1905

This commit replaces the unions with records whose alternatives do not
hold a type, so that they will be parsed into with yaml-to-dhall in a
deterministic way.